### PR TITLE
Fix for deprecation of several things in 2.37

### DIFF
--- a/src/devtools-panel/utils/remote-functions/getMetaData.ts
+++ b/src/devtools-panel/utils/remote-functions/getMetaData.ts
@@ -1,5 +1,3 @@
-import { getGameMetaData } from "../api";
-
 export interface GameMetaData {
   name: string;
   ifId: string;
@@ -111,7 +109,7 @@ export function getGameMetaFn(): GameMetaData | null {
         };
       }
 
-      const storageCapacity = 5242880; // 5MB
+      const storageCapacity = 5242880;
       const storageUsed = getLocalStorageUsed();
       const storageUsedPct = (storageUsed / storageCapacity) * 100;
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,6 +12,7 @@ declare global {
     };
     SugarCube: {
       Config: {
+        saves: any;
         passages: {
           start: string;
         };
@@ -21,6 +22,7 @@ declare global {
         };
       };
       Save: {
+        browser: any;
         slots: {
           length: number;
           count(): number;
@@ -31,6 +33,7 @@ declare global {
         passage: string;
       };
       Story: {
+        name: string;
         title: string;
         get ifId(): string;
       };


### PR DESCRIPTION
Story.title is deprecated. Fixed

Save.slots.length is deprecated. Fixed

 Save.slots.count() is deprecated. Fixed

They are still left in the code, if an author uses version 2.36 or below. 