### PR TITLE
Add configurable max history slices setting

### DIFF
--- a/src/devtools-panel/store/index.ts
+++ b/src/devtools-panel/store/index.ts
@@ -34,6 +34,7 @@ interface GameConfig {
 interface Settings {
   'diffLog.fontSize': number;
   'diffLog.pollingInterval': number;
+  'diffLog.maxHistorySlices': number;
   'diffLog.headingStyle': 'default' | 'distinct';
   'state.propertyOrder': PropertyOrder;
 }
@@ -192,6 +193,8 @@ export const setSetting = <T extends keyof Store['settings']>(
   setStore('settings', setting, value);
 };
 
+const getMaxHistorySlices = () => store.settings['diffLog.maxHistorySlices'];
+
 export async function startTrackingFrames() {
   let timeout = 0;
   setConnectionState('loading-game');
@@ -222,8 +225,9 @@ export async function startTrackingFrames() {
             passage: diffPackage.passage,
             changes: diffPackage.diffs,
           };
+          const maxFrames = getMaxHistorySlices();
 
-          setDiffFrames((cur) => [newFrame, ...cur].slice(0, 50));
+          setDiffFrames((cur) => [newFrame, ...cur].slice(0, maxFrames));
           setStateFrames((cur) => {
             const latestFrame = cur[0];
             if (!latestFrame) return cur;
@@ -233,7 +237,7 @@ export async function startTrackingFrames() {
               state: newState,
               diffingFrame: newFrame,
             };
-            return [newStateFrame, ...cur].slice(0, 50);
+            return [newStateFrame, ...cur].slice(0, maxFrames);
           });
         }
       }
@@ -293,6 +297,7 @@ function loadGlobalSettings() {
   const defaultSettings: Settings = {
     ['diffLog.fontSize']: 14,
     ['diffLog.pollingInterval']: 200,
+    ['diffLog.maxHistorySlices']: 50,
     ['diffLog.headingStyle']: 'default',
     ['state.propertyOrder']: 'type',
   };
@@ -308,6 +313,12 @@ function saveGlobalSettings() {
 
 createEffect(() => {
   if (store.settings) saveGlobalSettings();
+});
+
+createEffect(() => {
+  const maxFrames = store.settings['diffLog.maxHistorySlices'];
+  setDiffFrames((cur) => cur.slice(0, maxFrames));
+  setStateFrames((cur) => cur.slice(0, maxFrames));
 });
 
 createEffect(() => {

--- a/src/devtools-panel/views/Settings/DiffLogSettings.tsx
+++ b/src/devtools-panel/views/Settings/DiffLogSettings.tsx
@@ -2,12 +2,13 @@ import { createGetSetting, setSetting } from '@/devtools-panel/store';
 import { BooleanInput } from '@/devtools-panel/ui/inputs/BooleanInput';
 import { NumberInput } from '@/devtools-panel/ui/inputs/NumberInput';
 
-import { onFontSizeChange, onPollingIntervalChange } from './diffLogSetters';
+import { onFontSizeChange, onMaxHistorySlicesChange, onPollingIntervalChange } from './diffLogSetters';
 import { SettingControl } from './SettingControl';
 
 export function DiffLogSettings() {
   const getDiffLogFontSize = createGetSetting('diffLog.fontSize');
   const getDiffLogPollingInterval = createGetSetting('diffLog.pollingInterval');
+  const getDiffLogMaxHistorySlices = createGetSetting('diffLog.maxHistorySlices');
   const getDiffLogHeadingStyle = createGetSetting('diffLog.headingStyle');
 
   return (
@@ -27,6 +28,15 @@ export function DiffLogSettings() {
             inputProps={{ id }}
             value={getDiffLogPollingInterval()}
             onChange={onPollingIntervalChange}
+          />
+        )}
+      </SettingControl>
+      <SettingControl label="Max history slices">
+        {(id) => (
+          <NumberInput
+            inputProps={{ id }}
+            value={getDiffLogMaxHistorySlices()}
+            onChange={onMaxHistorySlicesChange}
           />
         )}
       </SettingControl>

--- a/src/devtools-panel/views/Settings/diffLogSetters.ts
+++ b/src/devtools-panel/views/Settings/diffLogSetters.ts
@@ -13,3 +13,8 @@ export const onPollingIntervalChange = createValidatingSetter<number>(
   (size) => setSetting('diffLog.pollingInterval', size),
   (interval) => interval > 100 && interval < 5000,
 );
+
+export const onMaxHistorySlicesChange = createValidatingSetter<number>(
+  (maxSlices) => setSetting('diffLog.maxHistorySlices', maxSlices),
+  (maxSlices) => Number.isInteger(maxSlices) && maxSlices >= 1 && maxSlices <= 500,
+);


### PR DESCRIPTION
Introduce a new setting for maximum history slices in the diff log, allowing users to configure the number of frames retained. Update related components and effects to utilize this new setting.

Primary desire was to limit potential memory being used especially with games with large sets of variables changing.  I noticed after prolonged periods of use, or rapid changes - dugger would become unstable or crash.  Just an assumption, but can't hurt to have an option.