### PR TITLE
Persist movable split widths across navigation

### DIFF
--- a/src/devtools-panel/pages/PassagesPage.tsx
+++ b/src/devtools-panel/pages/PassagesPage.tsx
@@ -10,6 +10,7 @@ export function PassagesPage() {
   const getSelectedPassage = createGetViewState('passage', 'selected');
   return (
     <MovableSplit
+      splitKey="passages-page"
       initialLeftWidthPercent={35}
       leftContent={
         <PassageList

--- a/src/devtools-panel/pages/StatePage.tsx
+++ b/src/devtools-panel/pages/StatePage.tsx
@@ -6,6 +6,7 @@ import { StateView } from '../views/State/StateView';
 export function StatePage() {
   return (
     <MovableSplit
+      splitKey="state-page"
       leftContent={<DiffLog />}
       rightContent={
         <>

--- a/src/devtools-panel/ui/util/MovableSplit.tsx
+++ b/src/devtools-panel/ui/util/MovableSplit.tsx
@@ -11,7 +11,7 @@ interface Interface {
 const splitWidthCache = new Map<string, string>();
 
 export function MovableSplit(props: Interface) {
-  const splitKey = untrack(() => props.splitKey);
+  const splitKey = props.splitKey;
   const initialWidthPct = props.initialLeftWidthPercent || 50;
   const [leftWidth, setLeftWidth] = createSignal(
     splitKey ? (splitWidthCache.get(splitKey) ?? `${initialWidthPct}%`) : `${initialWidthPct}%`,

--- a/src/devtools-panel/ui/util/MovableSplit.tsx
+++ b/src/devtools-panel/ui/util/MovableSplit.tsx
@@ -1,15 +1,21 @@
-import { createSignal, JSX, onCleanup, onMount } from 'solid-js';
+import { createSignal, JSX, onCleanup, onMount, untrack } from 'solid-js';
 
 interface Interface {
   leftContent: JSX.Element;
   rightContent: JSX.Element;
   initialLeftWidthPercent?: number;
+  splitKey?: string;
   class?: string;
 }
 
+const splitWidthCache = new Map<string, string>();
+
 export function MovableSplit(props: Interface) {
+  const splitKey = untrack(() => props.splitKey);
   const initialWidthPct = props.initialLeftWidthPercent || 50;
-  const [leftWidth, setLeftWidth] = createSignal(`${initialWidthPct}%`); // Percentage
+  const [leftWidth, setLeftWidth] = createSignal(
+    splitKey ? (splitWidthCache.get(splitKey) ?? `${initialWidthPct}%`) : `${initialWidthPct}%`,
+  );
   const [isDragging, setIsDragging] = createSignal(false);
   let containerRef: HTMLDivElement | undefined;
 
@@ -24,7 +30,9 @@ export function MovableSplit(props: Interface) {
     let newLeftWidth = e.clientX - containerRect.left;
 
     // Constrain width (e.g., min 10%, max 90%)
-    setLeftWidth(`${newLeftWidth - 4}px`);
+    const width = `${newLeftWidth - 4}px`;
+    setLeftWidth(width);
+    if (splitKey) splitWidthCache.set(splitKey, width);
   };
 
   const handleMouseUp = () => {

--- a/src/devtools-panel/ui/util/MovableSplit.tsx
+++ b/src/devtools-panel/ui/util/MovableSplit.tsx
@@ -1,4 +1,6 @@
-import { createSignal, JSX, onCleanup, onMount, untrack } from 'solid-js';
+import { createSignal, JSX, onCleanup, onMount } from 'solid-js';
+
+import { getPersistedValue, setPersistedValue } from './persistedValue';
 
 interface Interface {
   leftContent: JSX.Element;
@@ -8,13 +10,12 @@ interface Interface {
   class?: string;
 }
 
-const splitWidthCache = new Map<string, string>();
-
 export function MovableSplit(props: Interface) {
-  const splitKey = props.splitKey;
+  const splitKey = () => props.splitKey;
   const initialWidthPct = props.initialLeftWidthPercent || 50;
+  const fallbackWidth = `${initialWidthPct}%`;
   const [leftWidth, setLeftWidth] = createSignal(
-    splitKey ? (splitWidthCache.get(splitKey) ?? `${initialWidthPct}%`) : `${initialWidthPct}%`,
+    splitKey() ? getPersistedValue(splitKey()!, fallbackWidth) : fallbackWidth,
   );
   const [isDragging, setIsDragging] = createSignal(false);
   let containerRef: HTMLDivElement | undefined;
@@ -32,7 +33,7 @@ export function MovableSplit(props: Interface) {
     // Constrain width (e.g., min 10%, max 90%)
     const width = `${newLeftWidth - 4}px`;
     setLeftWidth(width);
-    if (splitKey) splitWidthCache.set(splitKey, width);
+    if (splitKey()) setPersistedValue(splitKey()!, width);
   };
 
   const handleMouseUp = () => {

--- a/src/devtools-panel/ui/util/persistedValue.ts
+++ b/src/devtools-panel/ui/util/persistedValue.ts
@@ -1,0 +1,9 @@
+const sessionValueCache = new Map<string, unknown>();
+
+export function getPersistedValue<T>(key: string, fallbackValue: T): T {
+  return (sessionValueCache.get(key) as T | undefined) ?? fallbackValue;
+}
+
+export function setPersistedValue<T>(key: string, value: T): void {
+  sessionValueCache.set(key, value);
+}

--- a/src/devtools-panel/views/Search/PassageResults.tsx
+++ b/src/devtools-panel/views/Search/PassageResults.tsx
@@ -23,6 +23,7 @@ export function PassageResults(props: Props) {
 
   return (
     <MovableSplit
+      splitKey="search-passage-results"
       class="flex flex-grow w-full overflow-hidden h-full"
       initialLeftWidthPercent={50}
       leftContent={

--- a/src/devtools-panel/views/Search/StateResults.tsx
+++ b/src/devtools-panel/views/Search/StateResults.tsx
@@ -14,8 +14,10 @@ interface Props {
   results: SearchResultState[];
 }
 
+let persistedSearchStatePathWidth = 256;
+
 export function StateResults(props: Props) {
-  const [getWidth, setWidth] = createSignal(256);
+  const [getWidth, setWidth] = createSignal(persistedSearchStatePathWidth);
   const onPathClick = (path: Path) => {
     setNavigationPage('state');
     setViewState('state', 'path', path);
@@ -35,7 +37,9 @@ export function StateResults(props: Props) {
     let newLeftWidth = e.clientX - containerRect.left;
 
     // -44 to cancel out icon column and col-gap
-    setWidth(newLeftWidth - 44);
+    const width = newLeftWidth - 44;
+    setWidth(width);
+    persistedSearchStatePathWidth = width;
   };
 
   const handleMouseUp = () => {

--- a/src/devtools-panel/views/Search/StateResults.tsx
+++ b/src/devtools-panel/views/Search/StateResults.tsx
@@ -6,6 +6,7 @@ import { getSpecificType } from '@/shared/type-helpers';
 
 import { setNavigationPage, setViewState } from '../../store';
 import { PrettyPath } from '../../ui/display/PrettyPath';
+import { getPersistedValue, setPersistedValue } from '../../ui/util/persistedValue';
 import { StateBooleanInput } from '../State/StateInputs/StateBooleanInput';
 import { StateNumberInput } from '../State/StateInputs/StateNumberInput';
 import { StateStringInput } from '../State/StateInputs/StateStringInput';
@@ -14,10 +15,10 @@ interface Props {
   results: SearchResultState[];
 }
 
-let persistedSearchStatePathWidth = 256;
+const stateResultsPathWidthKey = 'search-state-results-path-width';
 
 export function StateResults(props: Props) {
-  const [getWidth, setWidth] = createSignal(persistedSearchStatePathWidth);
+  const [getWidth, setWidth] = createSignal(getPersistedValue(stateResultsPathWidthKey, 256));
   const onPathClick = (path: Path) => {
     setNavigationPage('state');
     setViewState('state', 'path', path);
@@ -39,7 +40,7 @@ export function StateResults(props: Props) {
     // -44 to cancel out icon column and col-gap
     const width = newLeftWidth - 44;
     setWidth(width);
-    persistedSearchStatePathWidth = width;
+    setPersistedValue(stateResultsPathWidthKey, width);
   };
 
   const handleMouseUp = () => {


### PR DESCRIPTION
Enhance the user interface by allowing the split widths of movable components to persist across different pages. This includes fixes to ensure that the state-results split width is maintained during navigation between panes such as State and Search.  Only persists for the current session. Reinit of Twine Dugger will reinitialize the values to default.