### PR TITLE
feat(contextMenus): Add copy & cut to string and number fields context menus

### DIFF
--- a/src/devtools-panel/ui/inputs/NumberInput.tsx
+++ b/src/devtools-panel/ui/inputs/NumberInput.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
-import { JSX } from 'solid-js';
+import { createSignal, JSX } from 'solid-js';
 
 import { btnClass } from '../util/btnClass';
+import { createInputContextMenuHandler } from '../util/InputContextMenu';
 
 interface NumberInputProps {
   value: number;
@@ -17,8 +18,20 @@ const baseInputClasses =
   'block px-2 py-1 bg-gray-700 border border-gray-600 text-sm shadow-sm placeholder-gray-400 text-gray-100 focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500';
 
 export function NumberInput(props: NumberInputProps) {
-  const isDisabled = () => props.disabled || props.readOnly;
+  const [inputRef, setInputRef] = createSignal<HTMLInputElement | null>(null);
+  const isDisabled = () => !!(props.disabled || props.readOnly);
   const onKeyDown = (e: KeyboardEvent) => props.onKeyDown?.(e);
+
+  const onContextMenu = createInputContextMenuHandler({
+    getInput: () => inputRef(),
+    getRawValue: () => inputRef()?.value ?? String(props.value),
+    applyRawValue: (rawValue) => {
+      const parsed = Number(rawValue);
+      if (Number.isFinite(parsed)) props.onChange(parsed);
+    },
+    isDisabled: () => isDisabled(),
+    isReadOnly: () => !!props.readOnly,
+  });
 
   return (
     <div class={clsx('flex', props.className)}>
@@ -37,10 +50,12 @@ export function NumberInput(props: NumberInputProps) {
         -
       </button>
       <input
+        ref={setInputRef}
         type="number"
         value={props.value}
         onInput={(e) => props.onChange(e.target.valueAsNumber)}
         onKeyDown={onKeyDown}
+        onContextMenu={onContextMenu}
         disabled={props.disabled}
         readOnly={props.readOnly}
         class={clsx(

--- a/src/devtools-panel/ui/inputs/StringInput.tsx
+++ b/src/devtools-panel/ui/inputs/StringInput.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import { createEffect, createSignal, JSX } from 'solid-js';
 
+import { createInputContextMenuHandler } from '../util/InputContextMenu';
+
 interface StringInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -18,7 +20,15 @@ const baseInputClasses =
 
 export function StringInput(props: StringInputProps) {
   const onKeyDown = (e: KeyboardEvent) => props.onKeyDown?.(e);
-  const [ref, setRef] = createSignal<HTMLElement | null>(null);
+  const [ref, setRef] = createSignal<HTMLInputElement | null>(null);
+
+  const onContextMenu = createInputContextMenuHandler({
+    getInput: () => ref(),
+    getRawValue: () => props.value,
+    applyRawValue: (value) => props.onChange(value),
+    isDisabled: () => !!props.disabled,
+    isReadOnly: () => !!props.readOnly,
+  });
 
   createEffect(() => {
     if (props.autoFocus && ref()) ref()!.focus();
@@ -31,6 +41,7 @@ export function StringInput(props: StringInputProps) {
       value={props.value}
       onInput={(e) => props.onChange(e.target.value)}
       onKeyDown={onKeyDown}
+      onContextMenu={onContextMenu}
       placeholder={props.placeholder}
       disabled={props.disabled}
       readOnly={props.readOnly}

--- a/src/devtools-panel/ui/util/InputContextMenu.ts
+++ b/src/devtools-panel/ui/util/InputContextMenu.ts
@@ -1,0 +1,75 @@
+import { createContextMenuHandler } from './ContextMenu';
+
+interface InputContextMenuOptions<T> {
+  getInput: () => HTMLInputElement | null;
+  getRawValue: () => string;
+  applyRawValue: (value: string) => void;
+  isDisabled?: () => boolean;
+  isReadOnly?: () => boolean;
+  parseAndApplyValue?: (value: string) => void;
+}
+
+export function createInputContextMenuHandler(options: InputContextMenuOptions<unknown>) {
+  const selectedText = () => {
+    const input = options.getInput();
+    if (!input) return options.getRawValue();
+    const start = input.selectionStart ?? 0;
+    const end = input.selectionEnd ?? 0;
+    return start === end ? options.getRawValue() : options.getRawValue().slice(start, end);
+  };
+
+  const updateSelection = (value: string) => {
+    const input = options.getInput();
+    if (!input) return;
+    const start = input.selectionStart ?? 0;
+    const end = input.selectionEnd ?? 0;
+    const newValue = `${options.getRawValue().slice(0, start)}${value}${options.getRawValue().slice(end)}`;
+    if (options.parseAndApplyValue) {
+      options.parseAndApplyValue(newValue);
+    } else {
+      options.applyRawValue(newValue);
+    }
+    setTimeout(() => {
+      const position = start + value.length;
+      if (typeof input.setSelectionRange === 'function' && input.type !== 'number') {
+        input.setSelectionRange(position, position);
+      }
+    }, 0);
+  };
+
+  const removeSelection = () => updateSelection('');
+
+  const isInactive = () => (options.isDisabled?.() ?? false) || (options.isReadOnly?.() ?? false);
+
+  const tryWriteText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const writeText = async (text: string) => {
+    return await tryWriteText(text);
+  };
+
+  return createContextMenuHandler([
+    {
+      label: 'Copy',
+      onClick: async () => {
+        const text = selectedText();
+        await writeText(text);
+      },
+    },
+    {
+      label: 'Cut',
+      onClick: async () => {
+        if (isInactive()) return;
+        const success = await writeText(selectedText());
+        if (success) removeSelection();
+      },
+      disabled: () => isInactive(),
+    },
+  ]);
+}


### PR DESCRIPTION
Reintroduce support for copy and cut actions in the input context menu for both number and string inputs. This enhancement improves user interaction by allowing text manipulation directly from the context menu.

Paste was attempted to be introduced, but I encountered issues with pasting from clipboard into a devtools extension.  Some cross scripting chrome policy blocked it.  Adding clipboard read and write permissions in the manifest and using an offscreen document, but that didn't seem to do the trick.

Limiting scope to Copy and Cut which work with little fuss.