### PR TITLE
feat(watchpane): Added watchlist like dashboard with controls

### DIFF
--- a/src/devtools-panel/app/App.tsx
+++ b/src/devtools-panel/app/App.tsx
@@ -4,6 +4,7 @@ import { PassagesPage } from '../pages/PassagesPage';
 import { SearchPage } from '../pages/SearchPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { StatePage } from '../pages/StatePage';
+import { WatchlistPage } from '../pages/WatchlistPage';
 import { getConnectionState, getNavigationPage, startTrackingFrames } from '../store';
 import { ContextMenuUI } from '../ui/util/ContextMenu';
 import { PromptDialogOutlet } from '../ui/util/Prompt';
@@ -69,6 +70,9 @@ function LiveContent() {
       </Match>
       <Match when={getNavigationPage() === 'passages'}>
         <PassagesPage />
+      </Match>
+      <Match when={getNavigationPage() === 'watchlist'}>
+        <WatchlistPage />
       </Match>
       <Match when={getNavigationPage() === 'settings'}>
         <SettingsPage />

--- a/src/devtools-panel/app/Navigation.tsx
+++ b/src/devtools-panel/app/Navigation.tsx
@@ -28,6 +28,11 @@ const navItems = [
     icon: 'content_copy',
   },
   {
+    id: 'watchlist',
+    text: 'Watchlist',
+    icon: 'visibility',
+  },
+  {
     id: 'settings',
     text: 'Settings',
     icon: 'settings',

--- a/src/devtools-panel/pages/WatchlistPage.tsx
+++ b/src/devtools-panel/pages/WatchlistPage.tsx
@@ -1,0 +1,9 @@
+import { WatchlistView } from '../views/Watchlist/WatchlistView';
+
+export function WatchlistPage() {
+  return (
+    <div class="w-full h-full flex flex-col overflow-hidden bg-gray-900">
+      <WatchlistView />
+    </div>
+  );
+}

--- a/src/devtools-panel/store/index.ts
+++ b/src/devtools-panel/store/index.ts
@@ -29,6 +29,7 @@ const getGlobalSettingsKey = () => `${LS_PREFIX}settings`;
 interface GameConfig {
   lockedPaths: Path[];
   filteredPaths: Path[];
+  watchlistPaths: Path[];
 }
 
 interface Settings {
@@ -89,14 +90,16 @@ const [getStateFrames, setStateFrames] = createSignal<StateFrame[]>([]);
 const [getDiffFrames, setDiffFrames] = createSignal<DiffFrame[]>([]);
 const [getPassageData, setPassageData] = createSignal<ParsedPassageData[]>([]);
 
-export { getDiffFrames, getPassageData };
+export { getDiffFrames, getPassageData, getStateFrames };
 
 export const getConnectionState = createMemo(() => store.connection);
 export const getFilteredPaths = createMemo(() => store.gameConfig?.filteredPaths ?? []);
 export const getLockedPaths = createMemo(() => store.gameConfig?.lockedPaths ?? []);
+export const getWatchlistPaths = createMemo(() => store.gameConfig?.watchlistPaths ?? []);
 export const getGameMetaData = createMemo(() => store.gameMetaData);
 
 export const getLatestStateFrame = createMemo(() => getStateFrames()[0]!);
+export const getPreviousStateFrame = createMemo(() => getStateFrames()[1]);
 
 const getActiveStateFrame = createMemo(() => {
   const historyId = store.viewState.state.historyId;
@@ -171,6 +174,22 @@ export const removeFilteredPath = (path: Path) => {
 
 export const clearFilteredPaths = () => {
   setStore('gameConfig', 'filteredPaths', []);
+};
+
+export const addWatchlistPath = (path: Path) => {
+  const current = store.gameConfig?.watchlistPaths ?? [];
+  if (current.some((currentPath) => pathEquals(currentPath, path))) return;
+  setStore('gameConfig', 'watchlistPaths', [...current, path]);
+};
+
+export const removeWatchlistPath = (path: Path) => {
+  const current = store.gameConfig?.watchlistPaths ?? [];
+  const newPaths = current.filter((currentPath) => !pathEquals(currentPath, path));
+  setStore('gameConfig', 'watchlistPaths', newPaths);
+};
+
+export const clearWatchlistPaths = () => {
+  setStore('gameConfig', 'watchlistPaths', []);
 };
 
 export const addLockPath = (path: Path) => {
@@ -270,7 +289,7 @@ function parsePassage(passage: PassageData): ParsedPassageData {
 }
 
 function loadGameSettings() {
-  const defaultConfig: GameConfig = { filteredPaths: [], lockedPaths: [] };
+  const defaultConfig: GameConfig = { filteredPaths: [], lockedPaths: [], watchlistPaths: [] };
   const ifId = store.gameMetaData?.ifId;
   if (!ifId) return defaultConfig;
 
@@ -278,7 +297,9 @@ function loadGameSettings() {
   const lsData = localStorage.getItem(key);
   if (!lsData) return defaultConfig;
 
-  return { ...defaultConfig, ...(JSON.parse(lsData) as Partial<GameConfig>) };
+  const parsed = JSON.parse(lsData) as Partial<GameConfig> & { favoritePaths?: Path[] };
+  const migratedWatchlist = parsed.watchlistPaths ?? parsed.favoritePaths ?? [];
+  return { ...defaultConfig, ...parsed, watchlistPaths: migratedWatchlist };
 }
 
 function saveGameSettings() {

--- a/src/devtools-panel/views/DiffLog/DiffPath.tsx
+++ b/src/devtools-panel/views/DiffLog/DiffPath.tsx
@@ -1,4 +1,6 @@
+import { addWatchlistPath, getWatchlistPaths } from '@/devtools-panel/store';
 import { PrettyPath } from '@/devtools-panel/ui/display/PrettyPath';
+import { pathEquals } from '@/shared/path-equals';
 import { Path } from '@/shared/shared-types';
 
 import { createContextMenuHandler } from '../../ui/util/ContextMenu';
@@ -12,12 +14,26 @@ export function DiffPath(props: {
 }) {
   const fullPath = () =>
     props.leafKey === undefined ? props.path : [...props.path, props.leafKey];
-  const onContextMenu = createContextMenuHandler([
-    {
-      label: `Filter out changes to "${fullPath().join('.')}"`,
-      onClick: () => props.onAddFilter(fullPath()),
-    },
-  ]);
+
+  const onContextMenu = (event: MouseEvent) => {
+    const path = fullPath();
+    const isWatchlisted = () => getWatchlistPaths().some((item) => pathEquals(item, path));
+
+    createContextMenuHandler([
+      {
+        label: `Filter out changes to "${path.join('.')}"`,
+        onClick: () => props.onAddFilter(path),
+      },
+      {
+        label: () =>
+          isWatchlisted()
+            ? `Already in watchlist: "${path.join('.')}"`
+            : `Add "${path.join('.')}" to watchlist`,
+        onClick: () => addWatchlistPath(path),
+        disabled: () => isWatchlisted(),
+      },
+    ])(event);
+  };
 
   return (
     <code

--- a/src/devtools-panel/views/Search/StateResults.tsx
+++ b/src/devtools-panel/views/Search/StateResults.tsx
@@ -1,11 +1,14 @@
 import { createSignal, For, Match, onCleanup, onMount, Switch } from 'solid-js';
 
+import { addWatchlistPath, getWatchlistPaths } from '@/devtools-panel/store';
 import { TypeIcon } from '@/devtools-panel/ui/display/TypeIcon';
+import { pathEquals } from '@/shared/path-equals';
 import { Path, SearchResultState } from '@/shared/shared-types';
 import { getSpecificType } from '@/shared/type-helpers';
 
 import { setNavigationPage, setViewState } from '../../store';
 import { PrettyPath } from '../../ui/display/PrettyPath';
+import { createContextMenuHandler } from '../../ui/util/ContextMenu';
 import { StateBooleanInput } from '../State/StateInputs/StateBooleanInput';
 import { StateNumberInput } from '../State/StateInputs/StateNumberInput';
 import { StateStringInput } from '../State/StateInputs/StateStringInput';
@@ -14,8 +17,10 @@ interface Props {
   results: SearchResultState[];
 }
 
+let persistedSearchStatePathWidth = 256;
+
 export function StateResults(props: Props) {
-  const [getWidth, setWidth] = createSignal(256);
+  const [getWidth, setWidth] = createSignal(persistedSearchStatePathWidth);
   const onPathClick = (path: Path) => {
     setNavigationPage('state');
     setViewState('state', 'path', path);
@@ -32,10 +37,12 @@ export function StateResults(props: Props) {
   const handleMouseMove = (e: MouseEvent) => {
     if (!isDragging() || !containerRef) return;
     const containerRect = containerRef.getBoundingClientRect();
-    let newLeftWidth = e.clientX - containerRect.left;
+    const newLeftWidth = e.clientX - containerRect.left;
 
     // -44 to cancel out icon column and col-gap
-    setWidth(newLeftWidth - 44);
+    const width = newLeftWidth - 44;
+    setWidth(width);
+    persistedSearchStatePathWidth = width;
   };
 
   const handleMouseUp = () => {
@@ -66,8 +73,25 @@ export function StateResults(props: Props) {
         <For each={props.results}>
           {(result) => {
             const type = () => getSpecificType(result.value);
+            const isWatchlisted = () =>
+              getWatchlistPaths().some((path) => pathEquals(path, result.path));
+            const pathLabel = result.path.join('.');
+            const onContextMenu = createContextMenuHandler([
+              {
+                label: () =>
+                  isWatchlisted()
+                    ? `Already in watchlist: "${pathLabel}"`
+                    : `Add "${pathLabel}" to watchlist`,
+                onClick: () => addWatchlistPath(result.path),
+                disabled: () => isWatchlisted(),
+              },
+            ]);
+
             return (
-              <li class="grid grid-cols-subgrid col-span-full items-center px-2">
+              <li
+                class="grid grid-cols-subgrid col-span-full items-center px-2"
+                onContextMenu={onContextMenu}
+              >
                 {/* col 1: icon */}
                 <span class="col-start-1">
                   <TypeIcon type={type()} />

--- a/src/devtools-panel/views/State/ObjectNav.tsx
+++ b/src/devtools-panel/views/State/ObjectNav.tsx
@@ -3,16 +3,19 @@ import { createMemo, For } from 'solid-js';
 
 import {
   addLockPath,
+  addWatchlistPath,
   createGetSetting,
   createGetViewState,
   getActiveState,
   getLockedPaths,
+  getWatchlistPaths,
   removeLockPath,
   setViewState,
 } from '@/devtools-panel/store';
 import { showPromptDialog } from '@/devtools-panel/ui/util/Prompt';
 import { getLockStatus } from '@/devtools-panel/views/State/lock-helper';
 import { getObjectPathValue } from '@/shared/get-object-path-value';
+import { pathEquals } from '@/shared/path-equals';
 import {
   ContainerValue,
   LockStatus,
@@ -134,6 +137,7 @@ export function ObjectNav(props: Props) {
             return (
               <NavItem
                 child={child}
+                childPath={childPath()}
                 lockStatus={lockStatus()}
                 setLockState={(lock) => {
                   setStatePropertyLock(childPath(), lock);
@@ -160,6 +164,7 @@ interface ContainerChild {
 
 interface NavItemProps {
   child: ContainerChild;
+  childPath: Path;
   active: boolean;
   onClick: () => void;
   onDelete: () => void;
@@ -169,27 +174,38 @@ interface NavItemProps {
 }
 
 function NavItem(props: NavItemProps) {
-  const onContextMenu = createContextMenuHandler([
-    {
-      disabled: () => props.lockStatus === 'ancestor-lock',
-      label: () => {
-        return props.lockStatus !== 'locked'
-          ? `Lock "${props.child.text}"`
-          : `Unlock "${props.child.text}"`;
+  const isWatchlisted = () => getWatchlistPaths().some((path) => pathEquals(path, props.childPath));
+
+  const onContextMenu = (event: MouseEvent) =>
+    createContextMenuHandler([
+      {
+        disabled: () => props.lockStatus === 'ancestor-lock',
+        label: () => {
+          return props.lockStatus !== 'locked'
+            ? `Lock "${props.child.text}"`
+            : `Unlock "${props.child.text}"`;
+        },
+        onClick: () => props.setLockState(props.lockStatus === 'unlocked'),
       },
-      onClick: () => props.setLockState(props.lockStatus === 'unlocked'),
-    },
-    {
-      label: () => `Duplicate "${props.child.text}"`,
-      onClick: () => props.onDuplicate(),
-      disabled: () => props.lockStatus === 'ancestor-lock',
-    },
-    {
-      label: () => `Delete "${props.child.text}"`,
-      onClick: () => props.onDelete(),
-      disabled: () => props.lockStatus !== 'unlocked',
-    },
-  ]);
+      {
+        label: () => `Duplicate "${props.child.text}"`,
+        onClick: () => props.onDuplicate(),
+        disabled: () => props.lockStatus === 'ancestor-lock',
+      },
+      {
+        label: () =>
+          isWatchlisted()
+            ? `Already in watchlist: "${props.child.text}"`
+            : `Add "${props.child.text}" to watchlist`,
+        onClick: () => addWatchlistPath(props.childPath),
+        disabled: () => isWatchlisted(),
+      },
+      {
+        label: () => `Delete "${props.child.text}"`,
+        onClick: () => props.onDelete(),
+        disabled: () => props.lockStatus !== 'unlocked',
+      },
+    ])(event);
 
   return (
     <li onContextMenu={onContextMenu}>

--- a/src/devtools-panel/views/Watchlist/WatchlistView.tsx
+++ b/src/devtools-panel/views/Watchlist/WatchlistView.tsx
@@ -1,0 +1,338 @@
+import { createEffect, createMemo, createSignal, For, Match, Show, Switch } from 'solid-js';
+
+import { setState, setStatePropertyLock } from '@/devtools-panel/api/api';
+import {
+  addLockPath,
+  clearWatchlistPaths,
+  getDiffFrames,
+  getLockedPaths,
+  getStateFrames,
+  getWatchlistPaths,
+  removeLockPath,
+  removeWatchlistPath,
+  setNavigationPage,
+  setViewState,
+} from '@/devtools-panel/store';
+import { PrettyPath } from '@/devtools-panel/ui/display/PrettyPath';
+import { NumberInput } from '@/devtools-panel/ui/inputs/NumberInput';
+import { SaveButton } from '@/devtools-panel/ui/inputs/SaveButton';
+import { StringInput } from '@/devtools-panel/ui/inputs/StringInput';
+import { MutationBadge } from '@/devtools-panel/views/DiffLog/MutationBadge';
+import { RenderValue } from '@/devtools-panel/views/DiffLog/RenderValue';
+import { getLockStatus } from '@/devtools-panel/views/State/lock-helper';
+import { getObjectPathValue } from '@/shared/get-object-path-value';
+import { pathEquals } from '@/shared/path-equals';
+import { Path } from '@/shared/shared-types';
+import { getSpecificType } from '@/shared/type-helpers';
+
+import { BooleanInput } from '../../ui/inputs/BooleanInput';
+
+export function WatchlistView() {
+  const watchlistPaths = createMemo(() => getWatchlistPaths());
+
+  return (
+    <div class="flex-1 p-3 flex flex-col gap-3 overflow-hidden">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-lg font-semibold text-gray-200">Watchlist</h2>
+        <button
+          type="button"
+          class="px-2 py-1 rounded text-xs bg-red-700/70 hover:bg-red-600 disabled:opacity-40 disabled:cursor-default"
+          onClick={clearWatchlistPaths}
+          disabled={!watchlistPaths().length}
+        >
+          Clear all
+        </button>
+      </div>
+
+      <Show
+        when={watchlistPaths().length}
+        fallback={
+          <div class="flex-1 grid place-items-center text-gray-400 border border-dashed border-gray-700 rounded-md">
+            Right click a diff path and choose Add to watchlist.
+          </div>
+        }
+      >
+        <ul class="grid gap-1 overflow-auto pr-1">
+          <For each={watchlistPaths()}>
+            {(path) => (
+              <li>
+                <WatchlistRow path={path} />
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+    </div>
+  );
+}
+
+function WatchlistRow(props: { path: Path }) {
+  const currentValue = createMemo(() => {
+    const latest = getStateFrames()[0]?.state;
+    if (!latest) return undefined;
+    return getObjectPathValue(latest, props.path);
+  });
+
+  const previousValue = createMemo(() => {
+    const previous = getStateFrames()[1]?.state;
+    if (!previous) return undefined;
+    return getObjectPathValue(previous, props.path);
+  });
+
+  const type = createMemo(() => getSpecificType(currentValue()));
+
+  const mutationKind = createMemo<'add' | 'del' | 'chg' | 'typ' | 'mov'>(() => {
+    const latestFrame = getDiffFrames()[0];
+    const path = props.path;
+
+    const change = latestFrame?.changes.find((diff) => {
+      if (diff.type === 'object' || diff.type === 'map') {
+        return pathEquals([...diff.path, diff.key], path);
+      }
+      return pathEquals(diff.path, path);
+    });
+
+    if (change) {
+      if (change.type === 'type-changed') return 'typ';
+      if (change.type === 'string' || change.type === 'number' || change.type === 'boolean')
+        return 'chg';
+      if (change.type === 'array' && change.subtype === 'instructions') return 'mov';
+      if (
+        (change.type === 'array' ||
+          change.type === 'set' ||
+          change.type === 'object' ||
+          change.type === 'map') &&
+        change.subtype === 'add'
+      )
+        return 'add';
+      if (
+        (change.type === 'array' ||
+          change.type === 'set' ||
+          change.type === 'object' ||
+          change.type === 'map') &&
+        change.subtype === 'remove'
+      )
+        return 'del';
+    }
+
+    const prevType = getSpecificType(previousValue());
+    const curType = getSpecificType(currentValue());
+    if (prevType !== curType) return 'typ';
+    if (prevType === 'undefined' && curType !== 'undefined') return 'add';
+    if (prevType !== 'undefined' && curType === 'undefined') return 'del';
+    return 'chg';
+  });
+
+  const openInState = () => {
+    setViewState('state', 'historyId', -1);
+    setViewState('state', 'path', props.path);
+    setNavigationPage('state');
+  };
+
+  return (
+    <div class="border border-gray-700 bg-gray-800/70 rounded px-2 py-1 overflow-x-auto">
+      <div class="grid min-w-[620px] grid-cols-[minmax(275px,33%)_minmax(0,1fr)_275px] items-center gap-2">
+        <div class="min-w-0 flex items-center gap-1.5">
+          <MutationBadge kind={mutationKind()} />
+          <span class="text-sm font-semibold truncate">
+            <PrettyPath path={props.path} statePrefix />
+          </span>
+        </div>
+
+        <div class="min-w-0 w-full justify-self-start text-left text-xs text-gray-300 inline-flex items-center gap-1 overflow-hidden whitespace-nowrap">
+          <span class="min-w-0 max-w-[48%] overflow-hidden text-ellipsis whitespace-nowrap">
+            <RenderValue value={previousValue()} faded />
+          </span>
+          <span class="text-gray-500">-&gt;</span>
+          <span class="min-w-0 max-w-[48%] overflow-hidden text-ellipsis whitespace-nowrap">
+            <RenderValue value={currentValue()} />
+          </span>
+        </div>
+
+        <div class="w-full justify-self-end flex items-center justify-end gap-1 min-w-0 overflow-x-auto whitespace-nowrap">
+          <WatchlistPrimitiveInput path={props.path} type={type()} />
+          <WatchlistLockButton path={props.path} />
+          <IconActionButton
+            label="Open in state"
+            icon="open_in_new"
+            onClick={openInState}
+            hoverClass="hover:text-emerald-300 hover:border-emerald-500/70"
+          />
+          <IconActionButton
+            label="Remove from watchlist"
+            icon="close"
+            onClick={() => removeWatchlistPath(props.path)}
+            hoverClass="hover:text-red-300 hover:border-red-500/70"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WatchlistPrimitiveInput(props: { path: Path; type: string }) {
+  const currentValue = createMemo(() => {
+    const latest = getStateFrames()[0]?.state;
+    if (!latest) return undefined;
+    return getObjectPathValue(latest, props.path);
+  });
+
+  const getPath = () => props.path;
+  const isDisabled = () => getLockStatus(getPath, getLockedPaths) !== 'unlocked';
+
+  const [stringValue, setStringValue] = createSignal('');
+  const [numberValue, setNumberValue] = createSignal(0);
+
+  createEffect(() => {
+    if (props.type === 'string') {
+      setStringValue(typeof currentValue() === 'string' ? (currentValue() as string) : '');
+    }
+    if (props.type === 'number') {
+      setNumberValue(typeof currentValue() === 'number' ? (currentValue() as number) : 0);
+    }
+  });
+
+  const saveString = async () => {
+    await setState(props.path, stringValue());
+  };
+
+  const saveNumber = async () => {
+    await setState(props.path, numberValue());
+  };
+
+  const hasStringChanges = () => stringValue() !== currentValue();
+  const hasNumberChanges = () => numberValue() !== currentValue();
+
+  const onStringKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !isDisabled()) saveString();
+    if (e.key === 'Escape')
+      setStringValue(typeof currentValue() === 'string' ? (currentValue() as string) : '');
+  };
+
+  const onNumberKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !isDisabled()) saveNumber();
+    if (e.key === 'Escape')
+      setNumberValue(typeof currentValue() === 'number' ? (currentValue() as number) : 0);
+  };
+
+  const setBoolean = async (value: boolean) => {
+    if (isDisabled()) return;
+    await setState(props.path, value);
+  };
+
+  return (
+    <div class="flex items-center gap-1">
+      <Switch>
+        <Match when={props.type === 'string'}>
+          <StringInput
+            value={stringValue()}
+            onChange={setStringValue}
+            onKeyDown={onStringKeyDown}
+            disabled={isDisabled()}
+            class="w-[180px]"
+          />
+          <Show when={hasStringChanges() && !isDisabled()}>
+            <SaveButton onClick={saveString} />
+          </Show>
+        </Match>
+
+        <Match when={props.type === 'number'}>
+          <NumberInput
+            value={numberValue()}
+            onChange={setNumberValue}
+            onKeyDown={onNumberKeyDown}
+            disabled={isDisabled()}
+          />
+          <Show when={hasNumberChanges() && !isDisabled()}>
+            <SaveButton onClick={saveNumber} />
+          </Show>
+        </Match>
+
+        <Match when={props.type === 'boolean'}>
+          <BooleanInput
+            value={typeof currentValue() === 'boolean' ? (currentValue() as boolean) : false}
+            onChange={setBoolean}
+            disabled={isDisabled()}
+          />
+        </Match>
+        <Match
+          when={props.type !== 'string' && props.type !== 'number' && props.type !== 'boolean'}
+        >
+          <span class="text-xs text-gray-400 px-2">Readonly</span>
+        </Match>
+      </Switch>
+    </div>
+  );
+}
+
+function WatchlistLockButton(props: { path: Path }) {
+  const getPath = () => props.path;
+  const lockStatus = () => getLockStatus(getPath, getLockedPaths);
+
+  const toggleLock = () => {
+    if (lockStatus() === 'locked') {
+      removeLockPath(props.path);
+      setStatePropertyLock(props.path, false);
+      return;
+    }
+    if (lockStatus() === 'unlocked') {
+      addLockPath(props.path);
+      setStatePropertyLock(props.path, true);
+    }
+  };
+
+  return (
+    <IconActionButton
+      label={
+        lockStatus() === 'locked'
+          ? 'Unlock value'
+          : lockStatus() === 'unlocked'
+            ? 'Lock value'
+            : 'Ancestor locked'
+      }
+      icon={lockStatus() === 'locked' ? 'lock' : 'lock_open'}
+      onClick={toggleLock}
+      hoverClass={
+        lockStatus() === 'locked'
+          ? 'hover:text-red-300 hover:border-red-500/70 hover:bg-red-900/20'
+          : 'hover:text-amber-300 hover:border-amber-500/70'
+      }
+      activeClass={
+        lockStatus() === 'locked' ? 'text-amber-300 border-amber-500/60 bg-amber-900/20' : ''
+      }
+      disabled={lockStatus() === 'ancestor-lock'}
+    />
+  );
+}
+
+interface IconActionButtonProps {
+  label: string;
+  icon: string;
+  onClick: () => void;
+  hoverClass: string;
+  activeClass?: string;
+  disabled?: boolean;
+}
+
+function IconActionButton(props: IconActionButtonProps) {
+  return (
+    <button
+      type="button"
+      title={props.label}
+      aria-label={props.label}
+      onClick={() => props.onClick()}
+      disabled={props.disabled}
+      class={`
+        inline-flex size-7 items-center justify-center rounded-md border border-gray-600
+        text-gray-300 bg-gray-800/70 transition-colors
+        disabled:opacity-40 disabled:cursor-default
+        ${props.hoverClass}
+        ${props.activeClass ?? ''}
+      `}
+    >
+      <span class="material-symbols-outlined text-[18px] leading-none" aria-hidden="true">
+        {props.icon}
+      </span>
+    </button>
+  );
+}

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -130,7 +130,7 @@ export interface ParsedPassageData {
   tags: string[];
 }
 export type PropertyOrder = 'alphabetic' | 'type' | 'none';
-export type Page = 'state' | 'search' | 'passages' | 'settings';
+export type Page = 'state' | 'search' | 'passages' | 'watchlist' | 'settings';
 export type ConnectionState =
   | 'candidate-iframes'
   | 'killed'

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -49,7 +49,17 @@ export default defineConfig((): Options[] => [
                 .replace('./main.tsx', './devtools-panel.js')
                 .replace(
                   '<!--head-->',
-                  await getFontHtml(['search', 'data_object', 'settings', 'content_copy', 'close']),
+                  await getFontHtml([
+                    'search',
+                    'data_object',
+                    'settings',
+                    'content_copy',
+                    'close',
+                    'visibility',
+                    'lock',
+                    'lock_open',
+                    'open_in_new',
+                  ]),
                 ),
           });
 


### PR DESCRIPTION
**User story:**
- As a Dugger user tracking important state values,
- I want a new Favorites pane that stores favorited objects from Diff Log, history, or Search
- so that I can quickly inspect and update the variables I care about.

**Acceptance Criteria:**
- Watchlist pane is available in navigation.
- Right-click on diff, history or search items can add favorite path.
- Watchlist shows only saved objects.
- Watchlist items show latest diff and allow edit/save/lock actions.
- Watchlist items are stored in localStorage for persistency
- Watchlist items can be managed directly in Watchlist.  Edit, lock, remove, lock, open to history