### PR TITLE
perf(virtualLists): Performance improvements in rendering

### DIFF
--- a/src/devtools-panel/ui/util/VirtualizedList.tsx
+++ b/src/devtools-panel/ui/util/VirtualizedList.tsx
@@ -1,0 +1,86 @@
+import { createMemo, createSignal, For, JSX, onCleanup, onMount } from 'solid-js';
+
+interface VirtualizedListProps<T> {
+  items: T[];
+  itemHeight: number;
+  overscan?: number;
+  class?: string;
+  innerClass?: string;
+  renderItem: (item: T, index: number) => JSX.Element;
+}
+
+interface WindowedItem<T> {
+  item: T;
+  index: number;
+}
+
+export function VirtualizedList<T>(props: VirtualizedListProps<T>) {
+  const overscan = () => props.overscan ?? 8;
+  const [scrollTop, setScrollTop] = createSignal(0);
+  const [viewportHeight, setViewportHeight] = createSignal(0);
+  let containerRef: HTMLDivElement | undefined;
+
+  const totalHeight = createMemo(() => props.items.length * props.itemHeight);
+  const startIndex = createMemo(() => {
+    const raw = Math.floor(scrollTop() / props.itemHeight) - overscan();
+    return Math.max(0, raw);
+  });
+  const endIndex = createMemo(() => {
+    const visible = Math.ceil(viewportHeight() / props.itemHeight);
+    return Math.min(props.items.length, startIndex() + visible + overscan() * 2);
+  });
+
+  const visibleItems = createMemo<WindowedItem<T>[]>(() => {
+    const start = startIndex();
+    const end = endIndex();
+    const out: WindowedItem<T>[] = [];
+    for (let i = start; i < end; i++) {
+      const item = props.items[i];
+      if (item !== undefined) out.push({ item, index: i });
+    }
+    return out;
+  });
+
+  const onScroll = (e: Event) => {
+    const currentTarget = e.currentTarget as HTMLDivElement;
+    setScrollTop(currentTarget.scrollTop);
+  };
+
+  onMount(() => {
+    if (!containerRef) return;
+    setViewportHeight(containerRef.clientHeight);
+    const observer = new ResizeObserver(() => {
+      if (!containerRef) return;
+      setViewportHeight(containerRef.clientHeight);
+    });
+    observer.observe(containerRef);
+    onCleanup(() => observer.disconnect());
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      class={props.class ?? 'h-full overflow-auto'}
+      onScroll={onScroll}
+      data-virtualized-list="true"
+    >
+      <div class={props.innerClass} style={{ height: `${totalHeight()}px`, position: 'relative' }}>
+        <For each={visibleItems()}>
+          {(entry) => (
+            <div
+              style={{
+                position: 'absolute',
+                top: `${entry.index * props.itemHeight}px`,
+                left: '0',
+                right: '0',
+                height: `${props.itemHeight}px`,
+              }}
+            >
+              {props.renderItem(entry.item, entry.index)}
+            </div>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/src/devtools-panel/views/Passage/PassageList.tsx
+++ b/src/devtools-panel/views/Passage/PassageList.tsx
@@ -1,5 +1,6 @@
 import { For } from 'solid-js';
 
+import { VirtualizedList } from '@/devtools-panel/ui/util/VirtualizedList';
 import { ParsedPassageData } from '@/shared/shared-types';
 
 import { PassageListItem } from './PassageListItem';
@@ -10,21 +11,39 @@ interface Props {
   onPassageClick: (passage: ParsedPassageData) => void;
 }
 
+const VIRTUALIZE_THRESHOLD = 300;
+const PASSAGE_ROW_HEIGHT = 38;
+
 export function PassageList(props: Props) {
   return (
     <div class="px-4 py-2 h-full flex flex-col overflow-auto">
       <h1 class="font-bold text-xl mb-2">Passages</h1>
-      <ul class="flex-1 flex flex-col overflow-auto">
-        <For each={props.passages}>
-          {(item) => (
+      {props.passages.length > VIRTUALIZE_THRESHOLD ? (
+        <VirtualizedList
+          class="flex-1 overflow-auto"
+          items={props.passages}
+          itemHeight={PASSAGE_ROW_HEIGHT}
+          renderItem={(item) => (
             <PassageListItem
               passageData={item}
               onClick={() => props.onPassageClick(item)}
               active={props.selectedPassage?.id === item.id}
             />
           )}
-        </For>
-      </ul>
+        />
+      ) : (
+        <ul class="flex-1 flex flex-col overflow-auto">
+          <For each={props.passages}>
+            {(item) => (
+              <PassageListItem
+                passageData={item}
+                onClick={() => props.onPassageClick(item)}
+                active={props.selectedPassage?.id === item.id}
+              />
+            )}
+          </For>
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/devtools-panel/views/Passage/PassageListItem.tsx
+++ b/src/devtools-panel/views/Passage/PassageListItem.tsx
@@ -12,7 +12,7 @@ interface ListItemProps {
 
 export function PassageListItem(props: ListItemProps) {
   return (
-    <li class="border-t last:border-b border-slate-400 flex">
+    <div class="border-t border-slate-400 flex">
       <button
         type="button"
         onClick={() => props.onClick()}
@@ -28,6 +28,6 @@ export function PassageListItem(props: ListItemProps) {
           <For each={props.passageData.tags}>{(tag) => <Tag tag={tag} />}</For>
         </div>
       </button>
-    </li>
+    </div>
   );
 }

--- a/src/devtools-panel/views/Search/PassageResults.tsx
+++ b/src/devtools-panel/views/Search/PassageResults.tsx
@@ -2,6 +2,7 @@ import { For, Match, Switch } from 'solid-js';
 
 import { Code } from '@/devtools-panel/ui/code';
 import { MovableSplit } from '@/devtools-panel/ui/util/MovableSplit';
+import { VirtualizedList } from '@/devtools-panel/ui/util/VirtualizedList';
 import { ParsedPassageData } from '@/shared/shared-types';
 
 import { createGetViewState, getGameMetaData, setNavigationPage, setViewState } from '../../store';
@@ -12,6 +13,9 @@ import { PassageView } from '../Passage/PassageView';
 interface Props {
   results: ParsedPassageData[];
 }
+
+const VIRTUALIZE_THRESHOLD = 300;
+const PASSAGE_ROW_HEIGHT = 38;
 
 export function PassageResults(props: Props) {
   const onPassageClick = (passage: ParsedPassageData) => {
@@ -26,13 +30,24 @@ export function PassageResults(props: Props) {
       class="flex flex-grow w-full overflow-hidden h-full"
       initialLeftWidthPercent={50}
       leftContent={
-        <ul class="h-full overflow-auto">
-          <For each={props.results}>
-            {(result) => (
+        props.results.length > VIRTUALIZE_THRESHOLD ? (
+          <VirtualizedList
+            class="h-full overflow-auto"
+            items={props.results}
+            itemHeight={PASSAGE_ROW_HEIGHT}
+            renderItem={(result) => (
               <PassageListItem passageData={result} onClick={() => onPassageClick(result)} />
             )}
-          </For>
-        </ul>
+          />
+        ) : (
+          <ul class="h-full overflow-auto">
+            <For each={props.results}>
+              {(result) => (
+                <PassageListItem passageData={result} onClick={() => onPassageClick(result)} />
+              )}
+            </For>
+          </ul>
+        )
       }
       rightContent={
         <div class="w-full h-full flex flex-col">

--- a/src/devtools-panel/views/Search/StateResults.tsx
+++ b/src/devtools-panel/views/Search/StateResults.tsx
@@ -6,6 +6,7 @@ import { getSpecificType } from '@/shared/type-helpers';
 
 import { setNavigationPage, setViewState } from '../../store';
 import { PrettyPath } from '../../ui/display/PrettyPath';
+import { VirtualizedList } from '../../ui/util/VirtualizedList';
 import { StateBooleanInput } from '../State/StateInputs/StateBooleanInput';
 import { StateNumberInput } from '../State/StateInputs/StateNumberInput';
 import { StateStringInput } from '../State/StateInputs/StateStringInput';
@@ -13,6 +14,9 @@ import { StateStringInput } from '../State/StateInputs/StateStringInput';
 interface Props {
   results: SearchResultState[];
 }
+
+const VIRTUALIZE_THRESHOLD = 300;
+const STATE_ROW_HEIGHT = 44;
 
 export function StateResults(props: Props) {
   const [getWidth, setWidth] = createSignal(256);
@@ -42,6 +46,47 @@ export function StateResults(props: Props) {
     setIsDragging(false);
   };
 
+  const renderRow = (result: SearchResultState) => {
+    const type = () => getSpecificType(result.value);
+    return (
+      <div
+        class="grid items-center px-2 gap-x-2 h-full"
+        style={{ 'grid-template-columns': rowTemplate() }}
+      >
+        <span>
+          <TypeIcon type={type()} />
+        </span>
+
+        <span>
+          <button
+            type="button"
+            class="py-2 font-mono cursor-pointer hover:underline text-left text-nowrap overflow-hidden text-ellipsis max-w-full"
+            onClick={() => onPathClick(result.path)}
+          >
+            <PrettyPath path={result.path} />
+          </button>
+        </span>
+        <div />
+
+        <div class="justify-self-start w-full">
+          <Switch>
+            <Match when={type() === 'string'}>
+              <StateStringInput path={result.path} />
+            </Match>
+            <Match when={type() === 'number'}>
+              <StateNumberInput path={result.path} />
+            </Match>
+            <Match when={type() === 'boolean'}>
+              <StateBooleanInput path={result.path} />
+            </Match>
+          </Switch>
+        </div>
+      </div>
+    );
+  };
+
+  const rowTemplate = () => `auto minmax(auto,${getWidth()}px) 8px 1fr`;
+
   onMount(() => {
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
@@ -59,51 +104,23 @@ export function StateResults(props: Props) {
         style={{ left: `${44 + getWidth()}px` }}
         onMouseDown={handleMouseDown}
       />
-      <ul
-        class="grid items-center gap-x-2 gap-y-1 auto-rows-max h-full overflow-auto"
-        style={{ 'grid-template-columns': `auto minmax(auto,${getWidth()}px) 8px 1fr` }}
-      >
-        <For each={props.results}>
-          {(result) => {
-            const type = () => getSpecificType(result.value);
-            return (
-              <li class="grid grid-cols-subgrid col-span-full items-center px-2">
-                {/* col 1: icon */}
-                <span class="col-start-1">
-                  <TypeIcon type={type()} />
-                </span>
-
-                {/* col 2: path */}
-                <span class="col-start-2">
-                  <button
-                    type="button"
-                    class="py-2 font-mono cursor-pointer hover:underline text-left text-nowrap overflow-hidden text-ellipsis max-w-full"
-                    onClick={() => onPathClick(result.path)}
-                  >
-                    <PrettyPath path={result.path} />
-                  </button>
-                </span>
-                <div class="col-start-3" />
-
-                {/* col 3: input (aligned across rows) */}
-                <div class="col-start-4 justify-self-start w-full">
-                  <Switch>
-                    <Match when={type() === 'string'}>
-                      <StateStringInput path={result.path} />
-                    </Match>
-                    <Match when={type() === 'number'}>
-                      <StateNumberInput path={result.path} />
-                    </Match>
-                    <Match when={type() === 'boolean'}>
-                      <StateBooleanInput path={result.path} />
-                    </Match>
-                  </Switch>
-                </div>
-              </li>
-            );
-          }}
-        </For>
-      </ul>
+      {props.results.length > VIRTUALIZE_THRESHOLD ? (
+        <VirtualizedList
+          class="h-full overflow-auto"
+          items={props.results}
+          itemHeight={STATE_ROW_HEIGHT}
+          renderItem={(result) => renderRow(result)}
+        />
+      ) : (
+        <ul
+          class="grid items-center gap-x-2 gap-y-1 auto-rows-max h-full overflow-auto"
+          style={{ 'grid-template-columns': rowTemplate() }}
+        >
+          <For each={props.results}>
+            {(result) => <li class="col-span-full">{renderRow(result)}</li>}
+          </For>
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/devtools-panel/views/State/ObjectNav.tsx
+++ b/src/devtools-panel/views/State/ObjectNav.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../api/api';
 import { TypeIcon } from '../../ui/display/TypeIcon';
 import { createContextMenuHandler } from '../../ui/util/ContextMenu';
+import { VirtualizedList } from '../../ui/util/VirtualizedList';
 import { AddPropertyDialog } from './dialogs/AddPropertyDialog';
 import { DuplicateKeyDialog } from './dialogs/DuplicateKeyDialog';
 import { createSorter } from './property-sorter';
@@ -44,6 +45,9 @@ interface Props {
   path: Path;
   selectedProperty?: string | number;
 }
+
+const NAV_VIRTUALIZE_THRESHOLD = 200;
+const NAV_ROW_HEIGHT = 30;
 
 export function ObjectNav(props: Props) {
   const getName = () => props.path[props.path.length - 1];
@@ -65,12 +69,13 @@ export function ObjectNav(props: Props) {
           : sorter(Object.keys(object));
 
     // Convert to child key format
-    return rawKeys.map(
+    const children = rawKeys.map(
       (key): ContainerChild => ({
         text: key,
         type: getSpecificType(object instanceof Map ? object.get(key) : object[key]),
       }),
     );
+    return children;
   });
 
   const onDuplicate = async (property: string | number) => {
@@ -113,8 +118,28 @@ export function ObjectNav(props: Props) {
     await deleteFromState(path);
   };
 
+  const renderChild = (child: ContainerChild) => {
+    const childPath = () => [...props.path, child.text] as Path;
+    const lockStatus = () => getLockStatus(childPath, getLockedPaths);
+    return (
+      <NavItem
+        child={child}
+        lockStatus={lockStatus}
+        setLockState={(lock) => {
+          setStatePropertyLock(childPath(), lock);
+          if (lock) addLockPath(childPath());
+          else removeLockPath(childPath());
+        }}
+        active={child.text === props.selectedProperty}
+        onClick={() => handlePropertyClick(child.text)}
+        onDelete={() => handleDelete(childPath())}
+        onDuplicate={() => onDuplicate(child.text)}
+      />
+    );
+  };
+
   return (
-    <div class="w-max max-w-3xs flex flex-col h-full px-2 border-r border-r-gray-700">
+    <div class="w-max min-w-3xs max-w-3xs flex flex-col h-full px-2 border-r border-r-gray-700">
       <p class="text-lg">{getName()}</p>
       <ul>
         <li>
@@ -126,29 +151,18 @@ export function ObjectNav(props: Props) {
           </a>
         </li>
       </ul>
-      <ul class="flex flex-1 flex-col overflow-auto">
-        <For each={getChildren()}>
-          {(child) => {
-            const childPath = () => [...props.path, child.text];
-            const lockStatus = () => getLockStatus(childPath, getLockedPaths);
-            return (
-              <NavItem
-                child={child}
-                lockStatus={lockStatus()}
-                setLockState={(lock) => {
-                  setStatePropertyLock(childPath(), lock);
-                  if (lock) addLockPath(childPath());
-                  else removeLockPath(childPath());
-                }}
-                active={child.text === props.selectedProperty}
-                onClick={() => handlePropertyClick(child.text)}
-                onDelete={() => handleDelete(childPath())}
-                onDuplicate={() => onDuplicate(child.text)}
-              />
-            );
-          }}
-        </For>
-      </ul>
+      {getChildren().length > NAV_VIRTUALIZE_THRESHOLD ? (
+        <VirtualizedList
+          class="flex-1 overflow-auto"
+          items={getChildren()}
+          itemHeight={NAV_ROW_HEIGHT}
+          renderItem={(child) => renderChild(child)}
+        />
+      ) : (
+        <ul class="flex flex-1 flex-col overflow-auto">
+          <For each={getChildren()}>{(child) => renderChild(child)}</For>
+        </ul>
+      )}
     </div>
   );
 }
@@ -164,35 +178,35 @@ interface NavItemProps {
   onClick: () => void;
   onDelete: () => void;
   onDuplicate: () => void;
-  lockStatus: LockStatus;
+  lockStatus: () => LockStatus;
   setLockState: (lock: boolean) => void;
 }
 
 function NavItem(props: NavItemProps) {
   const onContextMenu = createContextMenuHandler([
     {
-      disabled: () => props.lockStatus === 'ancestor-lock',
+      disabled: () => props.lockStatus() === 'ancestor-lock',
       label: () => {
-        return props.lockStatus !== 'locked'
+        return props.lockStatus() !== 'locked'
           ? `Lock "${props.child.text}"`
           : `Unlock "${props.child.text}"`;
       },
-      onClick: () => props.setLockState(props.lockStatus === 'unlocked'),
+      onClick: () => props.setLockState(props.lockStatus() === 'unlocked'),
     },
     {
       label: () => `Duplicate "${props.child.text}"`,
       onClick: () => props.onDuplicate(),
-      disabled: () => props.lockStatus === 'ancestor-lock',
+      disabled: () => props.lockStatus() === 'ancestor-lock',
     },
     {
       label: () => `Delete "${props.child.text}"`,
       onClick: () => props.onDelete(),
-      disabled: () => props.lockStatus !== 'unlocked',
+      disabled: () => props.lockStatus() !== 'unlocked',
     },
   ]);
 
   return (
-    <li onContextMenu={onContextMenu}>
+    <div onContextMenu={onContextMenu}>
       <a
         onClick={() => props.onClick()}
         class={clsx(
@@ -205,10 +219,10 @@ function NavItem(props: NavItemProps) {
         <TypeIcon type={props.child.type} />
         <span class="flex-1 overflow-hidden overflow-ellipsis">
           {props.child.text}
-          {props.lockStatus === 'locked' && '🔒'}
-          {props.lockStatus === 'ancestor-lock' && <span class="saturate-0">🔒</span>}
+          {props.lockStatus() === 'locked' && '🔒'}
+          {props.lockStatus() === 'ancestor-lock' && <span class="saturate-0">🔒</span>}
         </span>
       </a>
-    </li>
+    </div>
   );
 }

--- a/src/devtools-panel/views/State/lock-helper.ts
+++ b/src/devtools-panel/views/State/lock-helper.ts
@@ -1,15 +1,32 @@
 import { LockStatus, Path } from '@/shared/shared-types';
 
-export function getLockStatus(getPath: () => Path, getLockedPaths: () => Path[]): LockStatus {
-  const path = getPath();
-  const lockedPaths = getLockedPaths().map((lockedPath) => lockedPath.join('\u0000'));
-  const pathStr = path.join('\u0000');
-  if (lockedPaths.includes(pathStr)) return 'locked';
+function getPathKey(path: Path) {
+  return path.join('\u0000');
+}
+
+export function createLockPathSet(lockedPaths: Path[]) {
+  return new Set(lockedPaths.map(getPathKey));
+}
+
+function getLockStatusFromSet(path: Path, lockSet: Set<string>): LockStatus {
+  const pathStr = getPathKey(path);
+  if (lockSet.has(pathStr)) return 'locked';
 
   for (let i = 1; i <= path.length; i++) {
-    const subPath = path.slice(0, i);
-    const subPathStr = subPath.join('\u0000');
-    if (lockedPaths.includes(subPathStr)) return 'ancestor-lock';
+    if (lockSet.has(getPathKey(path.slice(0, i)))) return 'ancestor-lock';
   }
   return 'unlocked';
+}
+
+export function getLockStatus(
+  pathOrGetter: Path | (() => Path),
+  lockSetOrGetter: Set<string> | (() => Path[]),
+): LockStatus {
+  if (typeof pathOrGetter === 'function' && typeof lockSetOrGetter === 'function') {
+    const path = pathOrGetter();
+    const lockSet = createLockPathSet(lockSetOrGetter());
+    return getLockStatusFromSet(path, lockSet);
+  }
+
+  return getLockStatusFromSet(pathOrGetter as Path, lockSetOrGetter as Set<string>);
 }


### PR DESCRIPTION
## Goal
Performance Improvements around rendering of the frames.  I was able to get the search, passage, and object nav to be very snappy.  


## Scope
- Search passage results list virtualization
- Passages page list virtualization
- State search results virtualization

## Acceptance
- Large lists no longer fully mounted; only window + overscan rendered.
- Split drag and panel resize avoid multi-second stalls at high counts.


Original search performance measurements showed around minimum of 5 seconds of render time for 15,000 passages.  Current is near zero ms.  Search feels much snappier due to it.
Original on load for object nav and diff log showed 400-600ms. This reduces objectNav to near zero.  Same changes to diff log got tricky, so I reverted on it.  

This also improves UX for say - moving the split row, or navigating to the different panes.  Search State, Search Passages and Passages are very smooth now.  When selecting state, and the diff log is empty, very snappy.  When filled with 4000+ events, approximately 600ms on load.

Highly recommend thoroughly checking this as time permits.  Also, if you have some ideas to improve the Diff Log rendering.  Lots of little changes.  

This was built on your main branch, but I tested merging with my fixes.  Conflicts around ObjectNav and StateResults.  Full merge completed here for reference:
https://github.com/czer323/twine-dugger/tree/test/dev-perf-merge-check
