### PR TITLE
Add debounce functionality to search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "tsc": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {
+    "@solid-primitives/scheduled": "1.5.3",
     "clsx": "2.1.1",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "oniguruma-to-es": "4.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@solid-primitives/scheduled':
+        specifier: 1.5.3
+        version: 1.5.3(solid-js@1.9.13)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -888,6 +891,11 @@ packages:
 
   '@rushstack/ts-command-line@5.0.2':
     resolution: {integrity: sha512-+AkJDbu1GFMPIU8Sb7TLVXDv/Q7Mkvx+wAjEl8XiXVVq+p1FmWW6M3LYpJMmoHNckSofeMecgWg5lfMwNAAsEQ==}
+
+  '@solid-primitives/scheduled@1.5.3':
+    resolution: {integrity: sha512-oNwLE6E6lxJAWrc8QXuwM0k2oU1BnANnkChwMw82aK1j3+mWGJkG1IFe5gCwbV+afYmjI76t9JJV3md/8tLw+g==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -3727,6 +3735,10 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
+
+  '@solid-primitives/scheduled@1.5.3(solid-js@1.9.13)':
+    dependencies:
+      solid-js: 1.9.13
 
   '@tailwindcss/node@4.3.0':
     dependencies:

--- a/src/devtools-panel/views/Search/create-searchResults.ts
+++ b/src/devtools-panel/views/Search/create-searchResults.ts
@@ -13,13 +13,11 @@ import { findPassageMatches, findStateMatches } from './search-utils';
 
 type AbortFn = () => void;
 const EMPTY: SearchResultsCombined = { state: [], passage: [] };
-const FIRST_KEY_DEBOUNCE_MS = 450;
-const SUBSEQUENT_KEY_DEBOUNCE_MS = 150;
+const SEARCH_RESULTS_DEBOUNCE_DELAY_MS = 450;
 
 export function createSearchResults() {
   const getQuery = createGetViewState('search', 'query');
-  const scheduleFirstKey = createScheduled((fn) => debounce(fn, FIRST_KEY_DEBOUNCE_MS));
-  const scheduleSubsequentKeys = createScheduled((fn) => debounce(fn, SUBSEQUENT_KEY_DEBOUNCE_MS));
+  const scheduleSearch = createScheduled((fn) => debounce(fn, SEARCH_RESULTS_DEBOUNCE_DELAY_MS));
 
   const [getSearchResults, setSearchResults] = createSignal<SearchResultsCombined>(EMPTY);
 
@@ -30,7 +28,7 @@ export function createSearchResults() {
     if (getNavigationPage() !== 'search') return null;
 
     const query = getQuery();
-    const shouldRunSearch = query.length <= 1 ? scheduleFirstKey() : scheduleSubsequentKeys();
+    const shouldRunSearch = scheduleSearch();
     const gameState = getLatestStateFrame();
     if (!query || !gameState) {
       setSearchResults(EMPTY);

--- a/src/devtools-panel/views/Search/create-searchResults.ts
+++ b/src/devtools-panel/views/Search/create-searchResults.ts
@@ -1,3 +1,4 @@
+import { createScheduled, debounce } from '@solid-primitives/scheduled';
 import { createEffect, createSignal } from 'solid-js';
 
 import {
@@ -12,9 +13,13 @@ import { findPassageMatches, findStateMatches } from './search-utils';
 
 type AbortFn = () => void;
 const EMPTY: SearchResultsCombined = { state: [], passage: [] };
+const FIRST_KEY_DEBOUNCE_MS = 450;
+const SUBSEQUENT_KEY_DEBOUNCE_MS = 150;
 
 export function createSearchResults() {
   const getQuery = createGetViewState('search', 'query');
+  const scheduleFirstKey = createScheduled((fn) => debounce(fn, FIRST_KEY_DEBOUNCE_MS));
+  const scheduleSubsequentKeys = createScheduled((fn) => debounce(fn, SUBSEQUENT_KEY_DEBOUNCE_MS));
 
   const [getSearchResults, setSearchResults] = createSignal<SearchResultsCombined>(EMPTY);
 
@@ -25,11 +30,13 @@ export function createSearchResults() {
     if (getNavigationPage() !== 'search') return null;
 
     const query = getQuery();
+    const shouldRunSearch = query.length <= 1 ? scheduleFirstKey() : scheduleSubsequentKeys();
     const gameState = getLatestStateFrame();
     if (!query || !gameState) {
       setSearchResults(EMPTY);
       return null;
     }
+    if (!shouldRunSearch) return null;
 
     const [statePromise, stateAbort] = findStateMatches(gameState.state, query);
     const [passagePromise, passageAbort] = findPassageMatches(getPassageData(), query);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -72,6 +72,7 @@ export default defineConfig((): UserConfig[] => [
     entry: { 'devtools-panel': 'src/devtools-panel/main.tsx' },
     deps: {
       alwaysBundle: [
+        '@solid-primitives/scheduled',
         'solid-js/web',
         'solid-js',
         'solid-js/store',


### PR DESCRIPTION
Implement debounce functionality for search queries using the `@solid-primitives/scheduled` library to improve performance and reduce unnecessary processing during user input.